### PR TITLE
UserGuide.adoc: Fix numbering bug by adding closing tag to box section

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -231,6 +231,7 @@ Format: `find KEYWORD [MORE_KEYWORDS]`
 * Only the name is searched.
 * Only full words will be matched e.g. `Han` will not match `Hans`
 * Persons matching at least one keyword will be returned (i.e. `OR` search). e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
+****
 
 * `list` +
 `delete 2` +
@@ -248,7 +249,6 @@ Format: `select INDEX`
 * Selects the guest and loads the Google search page the guest at the specified `INDEX`.
 * The index refers to the index number shown in the displayed guest list.
 * The index *must be a positive integer* `1, 2, 3, ...`
-
 ****
 
 Examples:


### PR DESCRIPTION
Previously, commands after 3.19 did not have a numbered display.