### PR TITLE
DeveloperGuide.adoc: Remove end tag which creates asciidoctor warning

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -530,7 +530,6 @@ to restrict access to the collection, and only allow certain methods such as add
 `Expense` or displaying on screen.
 * **Alternative 2: Use a `Set<Expense>` object**: Having the expenses ordered (e.g.
 chronologically) will be useful for generating a nice view of all the expenses incurred.
-// end::dataencryption[]
 
 == Documentation
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24848927/47221917-1f8ce180-d3e8-11e8-86ad-b179646cf0bf.png)

Resolves https://github.com/CS2103-AY1819S1-F11-2/main/issues/131